### PR TITLE
Attempt to fix test compilation errors

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -66,7 +66,7 @@ kotlin {
 
         androidUnitTest.dependencies {
             implementation(libs.junit)
-//            implementation(libs.sql.delight.jvm.driver)
+            implementation(libs.sql.delight.jvm.driver)
             implementation(libs.androidx.test.junit)
             implementation(libs.androidx.espresso.core)
         }
@@ -110,19 +110,23 @@ kotlin {
             implementation(libs.ktor.mock)
             @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
             implementation(compose.uiTest)
+            implementation(project(":core:database"))
+            implementation(project(":core:networking"))
+            implementation(project(":features:task:data"))
+            implementation(project(":features:task:domain"))
         }
 
         iosMain.dependencies {
         }
         iosTest.dependencies {
-//            implementation(libs.sql.delight.native.driver)
+            implementation(libs.sql.delight.native.driver)
         }
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutines.swing)
         }
         jvmTest.dependencies {
-//            implementation(libs.sql.delight.jvm.driver)
+            implementation(libs.sql.delight.jvm.driver)
         }
     }
 }


### PR DESCRIPTION
This commit includes the following changes:

- Investigated and resolved Android SDK configuration issues that were initially masking test compilation problems.
- Analyzed composeApp/build.gradle.kts:
  - Uncommented SQLDelight driver dependencies in androidUnitTest, iosTest, and jvmTest.
  - Added project dependencies (:core:database, :core:networking, :features:task:data, :features:task:domain) to commonTest.dependencies.
- Explored test file structures, locating DatabaseTestDriverFactory and CryptoHelper.kt.

The build is still failing due to numerous unresolved reference errors in composeApp's commonTest and jvmTest source sets. This suggests a deeper issue with dependency visibility or configuration in the Kotlin Multiplatform setup. Further investigation is needed to correctly configure dependencies for all test source sets.