### PR TITLE
Fix task dependency check logic

### DIFF
--- a/features/task/domain/src/commonMain/kotlin/com/zeyadgasser/playground/task/domain/usecase/CheckTaskUseCase.kt
+++ b/features/task/domain/src/commonMain/kotlin/com/zeyadgasser/playground/task/domain/usecase/CheckTaskUseCase.kt
@@ -10,10 +10,10 @@ import com.zeyadgasser.playground.task.domain.model.Value
 class CheckTaskUseCase(private val taskRepository: TaskRepository) {
 
     suspend fun invoke(task: TaskDomain): Pair<Operation, Value> {
-        val dependencies = task.dependencies.firstOrNull()?.toIntOrNull() ?: 0
+        val hasDependencies = task.dependencies.isNotEmpty()
         return if (task.done) {
             Operation(true) to Value(taskRepository.insertTask(task.copy(done = false)))
-        } else if (dependencies == 0 && !task.done) {
+        } else if (!hasDependencies) {
             Operation(true) to Value(taskRepository.insertTask(task.copy(done = true)))
         } else {
             Operation(false) to Value(task.done)

--- a/features/task/domain/src/commonTest/kotlin/com/zeyadgasser/playground/task/domain/usecase/CheckTaskUseCaseTest.kt
+++ b/features/task/domain/src/commonTest/kotlin/com/zeyadgasser/playground/task/domain/usecase/CheckTaskUseCaseTest.kt
@@ -41,4 +41,12 @@ class CheckTaskUseCaseTest {
         assertEquals(expected, checkTaskUseCase.invoke(taskDomain))
         verifyNoMoreCalls(taskRepository)
     }
+
+    @Test
+    fun invokeFailWithNonNumericDependency() = runTest {
+        val taskWithStringDep = TestingData.taskDomain.copy(dependencies = listOf("dep"))
+        val expected = Operation(false) to Value(false)
+        assertEquals(expected, checkTaskUseCase.invoke(taskWithStringDep))
+        verifyNoMoreCalls(taskRepository)
+    }
 }


### PR DESCRIPTION
## Summary
- fix CheckTaskUseCase to correctly detect dependencies
- add regression test covering non-numeric dependencies

## Testing
- `./gradlew :features:task:domain:allTests` *(fails: Could not resolve org.jetbrains.kotlin:kotlin-stdlib:2.1.0 - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68985d999218832f872a21c27249c202